### PR TITLE
Upgrade github-script version to v7 for using latest node lts version

### DIFF
--- a/.github/workflows/cd-tag-release.yaml
+++ b/.github/workflows/cd-tag-release.yaml
@@ -21,7 +21,7 @@ jobs:
           echo "TODAY=$(date --date='+9 hours' +%y.%m.%d)" >> $GITHUB_ENV
 
       - name: ✨ Deploy tag and release ✨
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const checkBranch = () => {


### PR DESCRIPTION

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/github-script@v6. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```


### Changes <br>actions/github-script v7 - https://github.com/actions/github-script?tab=readme-ov-file#v7

Version 7 of this action updated the runtime to Node 20 - https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runs-for-javascript-actions

All scripts are now run with Node 20 instead of Node 16 and are affected by any breaking changes between Node 16 and 20

The previews input now only applies to GraphQL API calls as REST API previews are no longer necessary - https://github.blog/changelog/2021-10-14-rest-api-preview-promotions/.

